### PR TITLE
Fix broken edit URL

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -148,7 +148,7 @@ params:
 
   editURL:
     enable: true
-    base: "https://github.com/shin13.github.io/edit/main/content"
+    base: "https://github.com/shin13/shin13.github.io/edit/main/content"
 
   blog:
     list:


### PR DESCRIPTION
## Summary
- correct repo path in editURL config

## Testing
- `hugo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a86eb1b288331927a1e07b7c396f3